### PR TITLE
안드로이드에서 로그인 요청 시 Content-Type 이 "application/json; charset=UTF-8"일 경우 실패하는 문제 해결

### DIFF
--- a/src/main/java/com/ncookie/imad/global/dto/response/ResponseCode.java
+++ b/src/main/java/com/ncookie/imad/global/dto/response/ResponseCode.java
@@ -11,6 +11,7 @@ public enum ResponseCode {
     ENTITY_NOT_FOUND(400,  " Entity Not Found"),
     INTERNAL_SERVER_ERROR(500, "Server Error"),
     INVALID_TYPE_VALUE(400, " Invalid Type Value"),
+    INVALID_CONTENT_TYPE(400, "잘못된 Content-Type 유형입니다."),
 
     // Spring Security
     UNAUTHORIZED_REQUEST(401, "잘못된 요청이거나 올바르지 않은 인증정보입니다."),

--- a/src/main/java/com/ncookie/imad/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ncookie/imad/global/jwt/filter/JwtAuthenticationFilter.java
@@ -143,7 +143,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 .ifPresentOrElse(user -> {
                     saveAuthentication(user);
                     log.info("JWT 인증 성공");
-                }, () -> log.error("JWT 인증 실패 : 존재하지 않는 회원"));
+                }, () -> log.info("JWT 인증 실패 : 존재하지 않는 회원"));
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     active: aws
+
+  devtools:
+    restart:
+      enabled: false


### PR DESCRIPTION
- 현재 IMAD의 안드로이드에서 네트워크 통신할 떄 헤더를 설정할 때 OkHttp3 라이브러리를 사용 중이다.
  - 이 라이브러리를 사용하면 "Content-Type" 헤더를 "application/json"으로 설정해도, 서버에서 로그를 확인하면 "application/json; charset=UTF-8"로 되어있는 문제가 있다.
  - 라이브러리에서 기본적으로 위와 같이 변환하는 것으로 보인다.
  - 이를 해결할 방법이 보이지 않아 서버에서 예외처리 부분을 수정했다.
- Request의 Content-Type이 null이거나, CONTENT_TYPE, CONTENT_TYPE_WITH_CHARSET와 일치하지 않으면 예외처리 수행하도록 했다.
  - 예외 발생 시 기존에는 `AuthenticationServiceException`를 throw 하도록 했지만, 수정 후 `BadRequestException`을 throw 해서 통일성 있게 예외처리가 되도록 했다.