### PR TITLE
#217 - 프로필 이미지 수정 시 에러 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/user/service/ProfileImageService.java
+++ b/src/main/java/com/ncookie/imad/domain/user/service/ProfileImageService.java
@@ -29,7 +29,7 @@ public class ProfileImageService {
 
         // 기존에 사용하던 프로필 이미지가 커스텀 이미지라면 S3에서 삭제
         String previousImage = user.getProfileImage();
-        if (!previousImage.startsWith("default_profile_image_")) {
+        if (previousImage != null && !previousImage.startsWith("default_profile_image_")) {
             awsS3Service.deleteFile(FileFolder.PROFILE_IMAGES, previousImage);
         }
 
@@ -49,7 +49,7 @@ public class ProfileImageService {
 
         // 기존에 사용하던 프로필 이미지가 커스텀 이미지라면 S3에서 삭제
         String previousImage = user.getProfileImage();
-        if (!previousImage.startsWith("default_profile_image_")) {
+        if (previousImage != null && !previousImage.startsWith("default_profile_image_")) {
             awsS3Service.deleteFile(FileFolder.PROFILE_IMAGES, previousImage);
         }
         


### PR DESCRIPTION
- previousImage에 관련한 처리를 할 때 먼저 null 체크를 하도록 했다.