### PR TITLE
오늘의 리뷰/게시글 신고 여부 데이터 추가

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/posting/controller/PostingController.java
+++ b/src/main/java/com/ncookie/imad/domain/posting/controller/PostingController.java
@@ -24,7 +24,7 @@ public class PostingController {
     public ApiResponse<PostingDetailsResponse> postingDetails(@RequestHeader("Authorization") String accessToken,
                                                               @PathVariable Long id) {
         return ApiResponse.createSuccess(ResponseCode.POSTING_GET_DETAILS_SUCCESS,
-                postingService.getPosting(accessToken, id, false));
+                postingService.getPostingById(accessToken, id, false));
     }
 
     @Description("게시글 등록")

--- a/src/main/java/com/ncookie/imad/domain/posting/dto/response/PostingDetailsResponse.java
+++ b/src/main/java/com/ncookie/imad/domain/posting/dto/response/PostingDetailsResponse.java
@@ -56,6 +56,9 @@ public class PostingDetailsResponse {
     private Long scrapId;
     private boolean scrapStatus;
 
+    // 신고 여부
+    private boolean isReported;
+
 
     public static PostingDetailsResponse toDTO(Posting posting, CommentListResponse commentList) {
         return PostingDetailsResponse.builder()

--- a/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
@@ -25,29 +25,13 @@ public class TodayPopularController {
     private final TodayPopularReviewService todayPopularReviewService;
     private final TodayPopularPostingService todayPopularPostingService;
 
-    private final ReviewService reviewService;
     private final PostingService postingService;
 
 
     @Description("오늘의 리뷰 조회")
     @GetMapping("/review")
-    public ApiResponse<ReviewDetailsResponse> getPopularReview() {
-        ReviewDetailsResponse todayPopularReview = todayPopularReviewService.getTodayPopularReview();
-
-        // 현재 인기 리뷰 데이터가 없는 상태이므로 좋아요가 가장 많은 리뷰 데이터 반환
-        if (todayPopularReview == null) {
-            log.info("인기 리뷰 데이터가 없으므로 좋아요가 가장 많은 리뷰를 조회합니다...");
-            ReviewDetailsResponse popularReview = reviewService.getMostLikeReview();
-
-            // 리뷰 좋아요 데이터도 없는 경우
-            if (popularReview == null) {
-                log.info("리뷰의 좋아요 데이터도 존재하지 않으므로 이에 맞는 응답을 반환합니다.");
-                return ApiResponse.createSuccess(ResponseCode.POPULAR_REVIEW_ALL_NULL, null);
-            }
-            return ApiResponse.createSuccess(ResponseCode.POPULAR_REVIEW_NULL_AND_GET_REVIEW, popularReview);
-        }
-
-        // 오늘의 리뷰 데이터 반환
+    public ApiResponse<ReviewDetailsResponse> getPopularReview(@RequestHeader("Authorization") String accessToken) {
+        ReviewDetailsResponse todayPopularReview = todayPopularReviewService.getTodayPopularReview(accessToken);
         return ApiResponse.createSuccess(ResponseCode.POPULAR_REVIEW_GET_SUCCESS, todayPopularReview);
     }
 

--- a/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
@@ -1,7 +1,6 @@
 package com.ncookie.imad.domain.ranking.controller;
 
 import com.ncookie.imad.domain.posting.dto.response.PostingDetailsResponse;
-import com.ncookie.imad.domain.posting.service.PostingService;
 import com.ncookie.imad.domain.ranking.service.TodayPopularPostingService;
 import com.ncookie.imad.domain.ranking.service.TodayPopularReviewService;
 import com.ncookie.imad.domain.review.dto.response.ReviewDetailsResponse;
@@ -21,10 +20,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/popular")
 public class TodayPopularController {
+
     private final TodayPopularReviewService todayPopularReviewService;
     private final TodayPopularPostingService todayPopularPostingService;
-
-    private final PostingService postingService;
 
 
     @Description("오늘의 리뷰 조회")

--- a/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/controller/TodayPopularController.java
@@ -5,7 +5,6 @@ import com.ncookie.imad.domain.posting.service.PostingService;
 import com.ncookie.imad.domain.ranking.service.TodayPopularPostingService;
 import com.ncookie.imad.domain.ranking.service.TodayPopularReviewService;
 import com.ncookie.imad.domain.review.dto.response.ReviewDetailsResponse;
-import com.ncookie.imad.domain.review.service.ReviewService;
 import com.ncookie.imad.global.dto.response.ApiResponse;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import jdk.jfr.Description;
@@ -39,21 +38,6 @@ public class TodayPopularController {
     @GetMapping("/posting")
     public ApiResponse<PostingDetailsResponse> getPopularPosting(@RequestHeader("Authorization") String accessToken) {
         PostingDetailsResponse todayPopularPosting = todayPopularPostingService.getTodayPopularPosting(accessToken);
-
-        // 현재 인기 게시글 데이터가 없는 상태이므로 좋아요가 가장 많은 게시글 데이터 반환
-        if (todayPopularPosting == null) {
-            log.info("인기 리뷰 데이터가 없으므로 좋아요가 가장 많은 리뷰를 조회합니다...");
-            PostingDetailsResponse mostLikePosting = postingService.getMostLikePosting(accessToken);
-
-            // 리뷰 좋아요 데이터도 없는 경우
-            if (mostLikePosting == null) {
-                log.info("리뷰의 좋아요 데이터도 존재하지 않으므로 이에 맞는 응답을 반환합니다.");
-                return ApiResponse.createSuccess(ResponseCode.POPULAR_POSTING_ALL_NULL, null);
-            }
-            return ApiResponse.createSuccess(ResponseCode.POPULAR_POSTING_NULL_AND_GET_POSTING, mostLikePosting);
-        }
-
-        // 오늘의 리뷰 데이터 반환
         return ApiResponse.createSuccess(ResponseCode.POPULAR_POSTING_GET_SUCCESS, todayPopularPosting);
     }
 }

--- a/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
@@ -4,6 +4,9 @@ import com.ncookie.imad.domain.posting.dto.response.PostingDetailsResponse;
 import com.ncookie.imad.domain.posting.service.PostingService;
 import com.ncookie.imad.domain.ranking.entity.TodayPopularPosting;
 import com.ncookie.imad.domain.ranking.repository.TodayPopularPostingsRepository;
+import com.ncookie.imad.domain.report.service.ReportService;
+import com.ncookie.imad.domain.user.entity.UserAccount;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.Utils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -18,28 +21,31 @@ import java.util.List;
 @Transactional
 @Service
 public class TodayPopularPostingService {
+    private final UserRetrievalService userRetrievalService;
     private final PostingService postingService;
+    private final ReportService reportService;
 
     private final TodayPopularPostingsRepository todayPopularPostingsRepository;
 
     public PostingDetailsResponse getTodayPopularPosting(String accessToken) {
         List<TodayPopularPosting> popularPostingList = todayPopularPostingsRepository.findTopByPopularScore();
+        PostingDetailsResponse todayPopularPosting;
         
-        // 인기 게시글 데이터가 존재하지 않으면 null 반환
         if (popularPostingList.isEmpty()) {
-            log.info("오늘의 게시글 데이터가 존재하지 않습니다.");
-            return null;
-        }
-
-        // 인기 점수가 가장 높은 게시글이 2개 이상일 때 랜덤으로 반환
-        if (popularPostingList.size() > 1) {
+            // 인기 게시글 데이터가 존재하지 않으면 null 반환
+            log.info("오늘의 게시글 데이터가 존재하지 않아 좋아요를 가장 많이 받은 게시글을 조회합니다.");
+            todayPopularPosting = postingService.getMostLikePosting(accessToken);
+        } else if (popularPostingList.size() > 1) {
+            // 인기 점수가 가장 높은 게시글이 2개 이상일 때 랜덤으로 반환
             int randomNum = Utils.getRandomNum(popularPostingList.size());
             
             log.info("인기 점수가 가장 높은 게시글이 2개 이상이므로 이 중 랜덤으로 반환합니다");
-            return postingService.getPosting(accessToken, popularPostingList.get(randomNum).getPosting(), true);
+            todayPopularPosting = postingService.getPosting(accessToken, popularPostingList.get(randomNum).getPosting(), true);
+        } else {
+            todayPopularPosting = postingService.getPosting(accessToken, popularPostingList.get(0).getPosting(), true);
         }
-        
+
         log.info("오늘의 게시글 데이터를 반환합니다");
-        return postingService.getPosting(accessToken, popularPostingList.get(0).getPosting(), true);
+        return todayPopularPosting;
     }
 }

--- a/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
@@ -36,10 +36,10 @@ public class TodayPopularPostingService {
             int randomNum = Utils.getRandomNum(popularPostingList.size());
             
             log.info("인기 점수가 가장 높은 게시글이 2개 이상이므로 이 중 랜덤으로 반환합니다");
-            return postingService.getPosting(accessToken, popularPostingList.get(randomNum).getPosting().getPostingId(), true);
+            return postingService.getPosting(accessToken, popularPostingList.get(randomNum).getPosting(), true);
         }
         
         log.info("오늘의 게시글 데이터를 반환합니다");
-        return postingService.getPosting(accessToken, popularPostingList.get(0).getPosting().getPostingId(), true);
+        return postingService.getPosting(accessToken, popularPostingList.get(0).getPosting(), true);
     }
 }

--- a/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularPostingService.java
@@ -4,9 +4,6 @@ import com.ncookie.imad.domain.posting.dto.response.PostingDetailsResponse;
 import com.ncookie.imad.domain.posting.service.PostingService;
 import com.ncookie.imad.domain.ranking.entity.TodayPopularPosting;
 import com.ncookie.imad.domain.ranking.repository.TodayPopularPostingsRepository;
-import com.ncookie.imad.domain.report.service.ReportService;
-import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.Utils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +18,7 @@ import java.util.List;
 @Transactional
 @Service
 public class TodayPopularPostingService {
-    private final UserRetrievalService userRetrievalService;
     private final PostingService postingService;
-    private final ReportService reportService;
 
     private final TodayPopularPostingsRepository todayPopularPostingsRepository;
 

--- a/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularReviewService.java
@@ -28,7 +28,7 @@ public class TodayPopularReviewService {
 
         if (popularReviewList.isEmpty()) {
             // 인기 리뷰 데이터가 존재하지 않으면 좋아요를 가장 많이 받은 리뷰 반환
-            log.info("오늘의 리뷰 데이터가 존재하지 않아 ");
+            log.info("오늘의 리뷰 데이터가 존재하지 않아 좋아요가 가장 많은 리뷰를 반환합니다.");
             todayPopularReview = reviewService.getMostLikeReview(accessToken);
         } else if (popularReviewList.size() > 1) {
             // 인기 리뷰 점수가 가장 높은 리뷰가 2개 이상일 때 랜덤으로 반환

--- a/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/ranking/service/TodayPopularReviewService.java
@@ -2,11 +2,8 @@ package com.ncookie.imad.domain.ranking.service;
 
 import com.ncookie.imad.domain.ranking.entity.TodayPopularReview;
 import com.ncookie.imad.domain.ranking.repository.TodayPopularReviewsRepository;
-import com.ncookie.imad.domain.report.service.ReportService;
 import com.ncookie.imad.domain.review.dto.response.ReviewDetailsResponse;
 import com.ncookie.imad.domain.review.service.ReviewService;
-import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.Utils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +18,7 @@ import java.util.List;
 @Transactional
 @Service
 public class TodayPopularReviewService {
-
-    private final UserRetrievalService userRetrievalService;
     private final ReviewService reviewService;
-    private final ReportService reportService;
 
     private final TodayPopularReviewsRepository todayPopularReviewsRepository;
 
@@ -44,17 +38,6 @@ public class TodayPopularReviewService {
             todayPopularReview = reviewService.getReview(accessToken, popularReviewList.get(randomNum).getReview());
         } else {
             todayPopularReview = reviewService.getReview(accessToken, popularReviewList.get(0).getReview());
-        }
-
-        if (todayPopularReview != null) {
-            UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
-            Long writtenUser = todayPopularReview.getUserId();
-            Long review = todayPopularReview.getReviewId();
-
-            // 신고 여부 조회 및 설정
-            boolean isReported = reportService.isReviewReportedById(writtenUser, review)
-                    || reportService.isReviewReportedById(user.getId(), writtenUser);
-            todayPopularReview.setReported(isReported);
         }
 
         log.info("오늘의 리뷰 데이터를 반환합니다");

--- a/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
+++ b/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
@@ -158,24 +158,9 @@ public class ReportService {
         return reviewReportRepository.existsByReporterAndReportedReview(reporter, review);
     }
 
-    // 리뷰 신고 여부 확인
-    public boolean isReviewReportedById(Long reporterId, Long reviewId) {
-        UserAccount reporter = userRetrievalService.getUserById(reporterId);
-        Review review = reviewRetrievalService.findByReviewId(reviewId);
-
-        return reviewReportRepository.existsByReporterAndReportedReview(reporter, review);
-    }
-
     // 게시글 신고 여부 확인
     public boolean isPostingReported(UserAccount reporter, Posting posting) {
         return postingReportRepository.existsByReporterAndReportedPosting(reporter, posting);
-    }
-
-    public boolean isPostingReportedById(Long reporterId, Long postingId) {
-        UserAccount reporter = userRetrievalService.getUserById(reporterId);
-        Posting posting = postingRetrievalService.getPostingEntityById(postingId);
-
-        return isPostingReported(reporter, posting);
     }
 
     // 댓글 신고 여부 확인

--- a/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
+++ b/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
@@ -171,6 +171,13 @@ public class ReportService {
         return postingReportRepository.existsByReporterAndReportedPosting(reporter, posting);
     }
 
+    public boolean isPostingReportedById(Long reporterId, Long postingId) {
+        UserAccount reporter = userRetrievalService.getUserById(reporterId);
+        Posting posting = postingRetrievalService.getPostingEntityById(postingId);
+
+        return isPostingReported(reporter, posting);
+    }
+
     // 댓글 신고 여부 확인
     public boolean isCommentReported(UserAccount reporter, Comment comment) {
         return commentReportRepository.existsByReporterAndReportedComment(reporter, comment);

--- a/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
+++ b/src/main/java/com/ncookie/imad/domain/report/service/ReportService.java
@@ -158,6 +158,14 @@ public class ReportService {
         return reviewReportRepository.existsByReporterAndReportedReview(reporter, review);
     }
 
+    // 리뷰 신고 여부 확인
+    public boolean isReviewReportedById(Long reporterId, Long reviewId) {
+        UserAccount reporter = userRetrievalService.getUserById(reporterId);
+        Review review = reviewRetrievalService.findByReviewId(reviewId);
+
+        return reviewReportRepository.existsByReporterAndReportedReview(reporter, review);
+    }
+
     // 게시글 신고 여부 확인
     public boolean isPostingReported(UserAccount reporter, Posting posting) {
         return postingReportRepository.existsByReporterAndReportedPosting(reporter, posting);

--- a/src/main/java/com/ncookie/imad/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ncookie/imad/domain/review/controller/ReviewController.java
@@ -21,7 +21,7 @@ public class ReviewController {
     @GetMapping("/{id}")
     public ApiResponse<ReviewDetailsResponse> reviewDetails(@RequestHeader("Authorization") String accessToken,
                                                             @PathVariable("id") Long id) {
-        return ApiResponse.createSuccess(ResponseCode.REVIEW_GET_DETAILS_SUCCESS, reviewService.getReview(accessToken, id));
+        return ApiResponse.createSuccess(ResponseCode.REVIEW_GET_DETAILS_SUCCESS, reviewService.getReviewById(accessToken, id));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
@@ -53,32 +53,35 @@ public class ReviewService {
     private final TodayPopularScoreService todayPopularScoreService;
     private final UserActivityService userActivityService;
 
-    public ReviewDetailsResponse getReview(String accessToken, Long reviewId) {
+    public ReviewDetailsResponse getReviewById(String accessToken, Long reviewId) {
         Optional<Review> optional = reviewRepository.findById(reviewId);
-        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
-            Review review = optional.get();
-
-            // 본인 작성 여부
-            boolean isAuthor;
-            if (user == null) {
-                isAuthor = false;
-            } else {
-                isAuthor = review.getUserAccount().getId().equals(user.getId());
-            }
-
-            ReviewLike reviewLike = reviewLikeService.findByUserAccountAndE(user, review);
-            int likeStatus = reviewLike == null ? 0 : reviewLike.getLikeStatus();
-
-            ReviewDetailsResponse reviewDetailsResponse = ReviewDetailsResponse.toDTO(review);
-            reviewDetailsResponse.setAuthor(isAuthor);
-            reviewDetailsResponse.setLikeStatus(likeStatus);
-
-            return reviewDetailsResponse;
+            return getReview(accessToken, optional.get());
         } else {
             throw new BadRequestException(ResponseCode.REVIEW_NOT_FOUND);
         }
+    }
+
+    public ReviewDetailsResponse getReview(String accessToken, Review review) {
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
+
+        // 본인 작성 여부
+        boolean isAuthor;
+        if (user == null) {
+            isAuthor = false;
+        } else {
+            isAuthor = review.getUserAccount().getId().equals(user.getId());
+        }
+
+        ReviewLike reviewLike = reviewLikeService.findByUserAccountAndE(user, review);
+        int likeStatus = reviewLike == null ? 0 : reviewLike.getLikeStatus();
+
+        ReviewDetailsResponse reviewDetailsResponse = ReviewDetailsResponse.toDTO(review);
+        reviewDetailsResponse.setAuthor(isAuthor);
+        reviewDetailsResponse.setLikeStatus(likeStatus);
+
+        return reviewDetailsResponse;
     }
 
     public ReviewListResponse getReviewList(String accessToken, Long contentsId, int pageNumber, String sortString, int order) {
@@ -124,7 +127,7 @@ public class ReviewService {
         );
     }
 
-    public ReviewDetailsResponse getMostLikeReview() {
+    public ReviewDetailsResponse getMostLikeReview(String accessToken) {
         List<Review> mostLikeReviewList = reviewRepository.findMostLikeReview();
 
         if (mostLikeReviewList.isEmpty()) {
@@ -133,9 +136,10 @@ public class ReviewService {
 
         if (mostLikeReviewList.size() > 1) {
             int randomNum = Utils.getRandomNum(mostLikeReviewList.size());
-            return ReviewDetailsResponse.toDTO(mostLikeReviewList.get(randomNum));
+            return getReview(accessToken, mostLikeReviewList.get(randomNum));
         }
-        return ReviewDetailsResponse.toDTO(mostLikeReviewList.get(0));
+
+        return getReview(accessToken, mostLikeReviewList.get(0));
     }
 
     public int getWrittenReviewCount(UserAccount user) {

--- a/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
@@ -81,6 +81,11 @@ public class ReviewService {
         reviewDetailsResponse.setAuthor(isAuthor);
         reviewDetailsResponse.setLikeStatus(likeStatus);
 
+        // 신고 여부
+        boolean isReported = reportService.isReviewReported(user, review)
+                || reportService.isUserReported(user, review.getUserAccount());
+        reviewDetailsResponse.setReported(isReported);
+
         return reviewDetailsResponse;
     }
 

--- a/src/main/java/com/ncookie/imad/global/dto/response/ResponseCode.java
+++ b/src/main/java/com/ncookie/imad/global/dto/response/ResponseCode.java
@@ -122,12 +122,7 @@ public enum ResponseCode {
     RANKING_WRONG_PERIOD(400, "옯바르지 않은 랭킹 기간입니다."),
 
     POPULAR_REVIEW_GET_SUCCESS(200, "정상적으로 오늘의 리뷰를 조회했습니다."),
-    POPULAR_REVIEW_NULL_AND_GET_REVIEW(200, "오늘의 리뷰 데이터가 없으므로 좋아요가 가장 많은 리뷰를 조회했습니다."),
-    POPULAR_REVIEW_ALL_NULL(200, "오늘의 리뷰와 리뷰의 좋아요 데이터 모두 존재하지 않습니다."),
-
     POPULAR_POSTING_GET_SUCCESS(200, "정상적으로 오늘의 게시글을 조회했습니다."),
-    POPULAR_POSTING_NULL_AND_GET_POSTING(200, "오늘의 게시글 데이터가 없으므로 좋아요가 가장 많은 게시글을 조회했습니다."),
-    POPULAR_POSTING_ALL_NULL(200, "오늘의 게시글과 게시글의 좋아요 데이터 모두 존재하지 않습니다."),
 
     // 추천
     RECOMMEND_GET_SUCCESS(200, "정상적으로 작품 추천 데이터를 조회했습니다."),


### PR DESCRIPTION
- 오늘의 리뷰/게시글 조회 시 `reported` 필드가 추가되도록 했다.
- 구현 과정에서 단일 리뷰/게시글 조회하는 코드를 일부 리팩토링해서 효율적으로 개선했다.
- 오늘의 리뷰/게시글 컨트롤러의 로직을 서비스 단으로 이전했다.

This closes #228 