### PR TITLE
리액트 소셜 로그인 성공 후 페이지 리디렉션

### DIFF
--- a/src/main/java/com/ncookie/imad/global/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/ncookie/imad/global/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
     public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    public static final String REDIRECT_ORIGIN_SITE_COOKIE_NAME = "origin_site";
     private static final int cookieExpireSeconds = 180;
 
     @Override
@@ -26,14 +27,17 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
         if (authorizationRequest == null) {
             CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
             CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_ORIGIN_SITE_COOKIE_NAME);
             return;
         }
 
         // 쿠키에 REDIRECT URL 첨부
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
         String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        String originSite = request.getParameter(REDIRECT_ORIGIN_SITE_COOKIE_NAME);
         if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
             CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+            CookieUtils.addCookie(response, REDIRECT_ORIGIN_SITE_COOKIE_NAME, originSite, cookieExpireSeconds);
         }
     }
 
@@ -45,5 +49,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
         CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_ORIGIN_SITE_COOKIE_NAME);
     }
 }

--- a/src/main/java/com/ncookie/imad/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ncookie/imad/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.ncookie.imad.global.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_ORIGIN_SITE_COOKIE_NAME;
 import static com.ncookie.imad.global.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @Slf4j
@@ -52,8 +53,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
 
-        Optional<String> cookieRedirectUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue);
+        Optional<String> cookieRedirectUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME).map(Cookie::getValue);
+        Optional<String> cookieOriginSite = CookieUtils.getCookie(request, REDIRECT_ORIGIN_SITE_COOKIE_NAME).map(Cookie::getValue);
 
         // 리액트에서 로그인 시도한 경우
         if (cookieRedirectUrl.isPresent()) {
@@ -61,6 +62,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                     .path("/success")
                     .queryParam("token", accessToken)
                     .queryParam("refresh_token", refreshToken)
+                    .queryParam("origin_site", cookieOriginSite)
                     .build().toUriString();
 
             log.info("리액트 서버의 소셜 로그인 요청 : redirect 작업을 수행합니다.");


### PR DESCRIPTION
이 pr은 리액트에서 소셜 로그인에 성공하면 마지막으로 사용 중이던 페이지의 url을 전달시키는 동작을 구현한다.

This closes #240 